### PR TITLE
Add options to toggle fading approach circles for hidden mod

### DIFF
--- a/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModHidden.cs
+++ b/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModHidden.cs
@@ -80,7 +80,6 @@ namespace osu.Game.Rulesets.Soyokaze.Mods
                 case DrawableHitCircle circle:
                     fadeTarget = circle.HitCircle;
                     if (!increaseVisibility)
-                        // using (circle.BeginAbsoluteSequence(hitObject.StartTime - hitObject.Preempt))
                         using (circle.BeginAbsoluteSequence(FadingApproachCircle.Value? fadeOutStartTime : hitObject.StartTime - hitObject.Preempt))
                         {
                             if (FadingApproachCircle.Value)

--- a/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModHidden.cs
+++ b/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModHidden.cs
@@ -2,8 +2,10 @@
 // See the LICENSE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Soyokaze.Objects;
@@ -13,6 +15,19 @@ namespace osu.Game.Rulesets.Soyokaze.Mods
 {
     public class SoyokazeModHidden : ModHidden
     {
+        [SettingSource("Fading Approach Circle", "Allow approach circles to fade instead of disappearing")]
+        public Bindable<bool> FadingApproachCircle { get; } = new BindableBool(false);
+
+        [SettingSource("Fading Approach Circle Speed", "Adjust the fading speed of approach circles")]
+        public Bindable<double> FadingApproachCircleSpeed { get; } = new BindableDouble
+        {
+            Precision = 0.05f,
+            MinValue = 0.5,
+            MaxValue = 2.0,
+            Default = 1.0,
+            Value = 1.0
+        };
+
         public override double ScoreMultiplier => 1.09;
         public override string Description => "IT'S UNREADABLE.";
 
@@ -65,9 +80,13 @@ namespace osu.Game.Rulesets.Soyokaze.Mods
                 case DrawableHitCircle circle:
                     fadeTarget = circle.HitCircle;
                     if (!increaseVisibility)
-                        using (circle.BeginAbsoluteSequence(hitObject.StartTime - hitObject.Preempt))
+                        // using (circle.BeginAbsoluteSequence(hitObject.StartTime - hitObject.Preempt))
+                        using (circle.BeginAbsoluteSequence(FadingApproachCircle.Value? fadeOutStartTime : hitObject.StartTime - hitObject.Preempt))
                         {
-                            circle.ApproachCircle.Hide();
+                            if (FadingApproachCircle.Value)
+                                circle.ApproachCircle.FadeOut(fadeOutDuration / FadingApproachCircleSpeed.Value);
+                            else
+                                circle.ApproachCircle.Hide();
                         }
                     goto default;
                 default:

--- a/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModHidden.cs
+++ b/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModHidden.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Soyokaze.Mods
         public Bindable<bool> FadingApproachCircle { get; } = new BindableBool(true);
 
         public override double ScoreMultiplier => 1.09;
-        public override string Description => "IT'S UNREADABLE.";
+        public override string Description => "Play with fading circles.";
 
         private const double fade_in_fraction= 0.4;
         private const double fade_out_fraction = 0.3;

--- a/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModHidden.cs
+++ b/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModHidden.cs
@@ -16,17 +16,7 @@ namespace osu.Game.Rulesets.Soyokaze.Mods
     public class SoyokazeModHidden : ModHidden
     {
         [SettingSource("Fading Approach Circle", "Allow approach circles to fade instead of disappearing")]
-        public Bindable<bool> FadingApproachCircle { get; } = new BindableBool(false);
-
-        [SettingSource("Fading Approach Circle Speed", "Adjust the fading speed of approach circles")]
-        public Bindable<double> FadingApproachCircleSpeed { get; } = new BindableDouble
-        {
-            Precision = 0.05f,
-            MinValue = 0.5,
-            MaxValue = 2.0,
-            Default = 1.0,
-            Value = 1.0
-        };
+        public Bindable<bool> FadingApproachCircle { get; } = new BindableBool(true);
 
         public override double ScoreMultiplier => 1.09;
         public override string Description => "IT'S UNREADABLE.";
@@ -80,14 +70,17 @@ namespace osu.Game.Rulesets.Soyokaze.Mods
                 case DrawableHitCircle circle:
                     fadeTarget = circle.HitCircle;
                     if (!increaseVisibility)
-                        using (circle.BeginAbsoluteSequence(FadingApproachCircle.Value? fadeOutStartTime : hitObject.StartTime - hitObject.Preempt))
-                        {
-                            if (FadingApproachCircle.Value)
-                                circle.ApproachCircle.FadeOut(fadeOutDuration / FadingApproachCircleSpeed.Value);
-                            else
+                        if (FadingApproachCircle.Value)
+                            using (circle.BeginAbsoluteSequence(fadeOutStartTime))
+                            {
+                                circle.ApproachCircle.FadeOut(fadeOutDuration * 0.8);
+                            }
+                        else
+                            using (circle.BeginAbsoluteSequence(hitObject.StartTime - hitObject.Preempt))
+                            {
                                 circle.ApproachCircle.Hide();
-                        }
-                    goto default;
+                            }
+                        goto default;
                 default:
                     using (fadeTarget.BeginAbsoluteSequence(fadeOutStartTime))
                     {


### PR DESCRIPTION
This PR allow player to makes approach circles fading in mod customization menu:
![image](https://user-images.githubusercontent.com/20136708/140630473-4cc6d51f-ac16-4505-ac94-6b2f832ce73c.png)

Fading approach circles makes hidden mod easier to read, and player can change the fading speed as well (if they finds the default speed is too difficult/too easy).

https://user-images.githubusercontent.com/20136708/140631038-aa649e3c-f44a-412b-8d78-cb6bcfc430df.mp4

