### PR TITLE
Fix unable to hit hold objects with Random mod

### DIFF
--- a/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModRandom.cs
+++ b/osu.Game.Rulesets.Soyokaze/Mods/SoyokazeModRandom.cs
@@ -18,7 +18,18 @@ namespace osu.Game.Rulesets.Soyokaze.Mods
             foreach (var obj in beatmap.HitObjects)
             {
                 if (obj is SoyokazeHitObject hitObject)
+                {
+                    if (obj is HoldCircle) continue;
                     hitObject.Button = (SoyokazeAction)RNG.Next(8);
+                    if (hitObject is Hold hold)
+                    {
+                        foreach (var nestedObj in hold.NestedHitObjects)
+                        {
+                            if (nestedObj is SoyokazeHitObject nestedHitObject)
+                                nestedHitObject.Button = hitObject.Button;
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This PR aims to fix the issue with hold objects when Random mod is active: you can't hit the randomized hold note because the hold circle is placed at different button.

The video below demonstrate the issue:

https://user-images.githubusercontent.com/20136708/147527828-2d15924a-1c14-4ebb-bce0-15d08bfbfa7b.mp4

I have also enabled "Allow edits by maintainers" so you can commit directly to my branch if you need to do some small changes.