### PR TITLE
Skinning: Improve kiai visualizer animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ KiaiVisualizerDefaultSpin: 1.5
 KiaiVisualizerKiaiSpin: -60
 KiaiVisualizerDefaultOpacity: 128
 KiaiVisualizerFirstFlashOpacity: 255
-KiaiVisualizerFlashOpacity: 192
+KiaiVisualizerFlashOpacity: 152
 
 [Colours]
 HoldHighlight: 0, 255, 0


### PR DESCRIPTION
* Fix beat index calculation so that kiai flashes occur on "down" beats (start of measures) in case of kiai times starting on "up" beats
* Add slight "push" to the spinning velocity when kiai flashes occur
* Dim default kiai flash color
