### PR TITLE
Skinning: Remove masking for hit circles to allow more flexible skinning

### DIFF
--- a/osu.Game.Rulesets.Soyokaze/Skinning/SkinnableHitCircle.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/SkinnableHitCircle.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Soyokaze.Skinning
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
             RelativeSizeAxes = Axes.Both;
-            Masking = true;
+            Masking = false;
 
             hitCircle = new SkinnableDrawable(
                 new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.HitCircle),


### PR DESCRIPTION
Fixes #219.

I think I originally did this so that circle size (CS) cannot be changed by player (in osu!std it doesn't matter if circles look larger because the hitbox stays the same). But to be honest, I don't think it matters at all anyway.
