### PR TITLE
Scoring: Use judgement timings that are more similar to osu!std

### DIFF
--- a/osu.Game.Rulesets.Soyokaze/Judgements/SoyokazeJudgement.cs
+++ b/osu.Game.Rulesets.Soyokaze/Judgements/SoyokazeJudgement.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Rulesets.Soyokaze.Judgements
 {
     public class SoyokazeJudgement : Judgement
     {
-        public override HitResult MaxResult => HitResult.Perfect;
+        public override HitResult MaxResult => HitResult.Great;
 
         protected override double HealthIncreaseFor(HitResult result)
         {

--- a/osu.Game.Rulesets.Soyokaze/Objects/Drawables/DrawableHold.cs
+++ b/osu.Game.Rulesets.Soyokaze/Objects/Drawables/DrawableHold.cs
@@ -201,15 +201,11 @@ namespace osu.Game.Rulesets.Soyokaze.Objects.Drawables
             double scoreFraction = (holdCircleFraction + holdFraction) / 2;
 
             HitResult result;
-            if (scoreFraction > 0.9)
-                result = HitResult.Perfect;
-            else if (scoreFraction > 0.8)
+            if (scoreFraction > 0.8)
                 result = HitResult.Great;
-            else if (scoreFraction > 0.7)
-                result = HitResult.Good;
-            else if (scoreFraction > 0.6)
-                result = HitResult.Ok;
             else if (scoreFraction > 0.5)
+                result = HitResult.Ok;
+            else if (scoreFraction > 0.3)
                 result = HitResult.Meh;
             else
                 result = HitResult.Miss;

--- a/osu.Game.Rulesets.Soyokaze/Objects/SoyokazeHitObject.cs
+++ b/osu.Game.Rulesets.Soyokaze/Objects/SoyokazeHitObject.cs
@@ -9,6 +9,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Soyokaze.Judgements;
+using osu.Game.Rulesets.Soyokaze.Scoring;
 using osu.Game.Rulesets.Soyokaze.UI;
 
 namespace osu.Game.Rulesets.Soyokaze.Objects
@@ -57,7 +58,7 @@ namespace osu.Game.Rulesets.Soyokaze.Objects
 
         public override Judgement CreateJudgement() => new SoyokazeJudgement();
 
-        protected override HitWindows CreateHitWindows() => new HitWindows();
+        protected override HitWindows CreateHitWindows() => new SoyokazeHitWindows();
 
         // IHasComboInformation Impl -----------------------------------
 

--- a/osu.Game.Rulesets.Soyokaze/Scoring/SoyokazeHitWindows.cs
+++ b/osu.Game.Rulesets.Soyokaze/Scoring/SoyokazeHitWindows.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
+// See the LICENSE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Soyokaze.Scoring
+{
+    public class SoyokazeHitWindows : HitWindows
+    {
+        internal static readonly DifficultyRange[] SOYOKAZE_RANGES =
+        {
+            new DifficultyRange(HitResult.Great, 80, 50, 25),
+            new DifficultyRange(HitResult.Ok, 140, 100, 70),
+            new DifficultyRange(HitResult.Meh, 200, 150, 115),
+            new DifficultyRange(HitResult.Miss, 400, 400, 400),
+        };
+
+        public override bool IsHitResultAllowed(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Great:
+                case HitResult.Ok:
+                case HitResult.Meh:
+                case HitResult.Miss:
+                    return true;
+            }
+
+            return false;
+        }
+
+        protected override DifficultyRange[] GetRanges() => SOYOKAZE_RANGES;
+    }
+}


### PR DESCRIPTION
Fixes #146.

The timings are not *exactly* the same, but slightly easier. This is because most osu!std maps are OD9+, even at low difficulties ~4★ (which then gets converted as a 3★ in soyokaze!). This is problematic because compared to the generic hit windows that soyokaze! currently uses, osu!std hit windows are much easier at lower ODs, but much harder at higher ODs. This was very noticeable, and my accuracy dropped 10%+ across most maps (even very easy ones, like Harumachi Clover). So directly using osu!std hit windows makes the ruleset very unfriendly, which is why this PR makes the hit windows a little easier (but not by much).