### PR TITLE
Skinning: Make judgements skinnable by taking them from osu!std

### DIFF
--- a/osu.Game.Rulesets.Soyokaze/Skinning/Legacy/SoyokazeLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Legacy/SoyokazeLegacySkinTransformer.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -15,35 +18,58 @@ namespace osu.Game.Rulesets.Soyokaze.Skinning.Legacy
         {
         }
 
-        public override Drawable GetDrawableComponent(ISkinComponentLookup component)
+        public override Drawable GetDrawableComponent(ISkinComponentLookup lookup)
         {
-            if (!(component is SoyokazeSkinComponentLookup soyokazeComponent))
-                return null;
-
-            switch (soyokazeComponent.Component)
+            switch (lookup)
             {
-                case SoyokazeSkinComponents.ApproachCircle:
-                case SoyokazeSkinComponents.Cursor:
-                case SoyokazeSkinComponents.HitCircle:
-                case SoyokazeSkinComponents.HitCircleOverlay:
-                case SoyokazeSkinComponents.HoldOverlay:
-                case SoyokazeSkinComponents.InputOverlayKey:
-                case SoyokazeSkinComponents.InputOverlayBackground:
-                case SoyokazeSkinComponents.KiaiVisualizerSquare:
+                // This was taken from LegacySkin.GetDrawableComponent(ISkinComponentLookup lookup)
+                case SkinComponentLookup<HitResult> resultComponent:
+                    // kind of wasteful that we throw this away, but should do for now.
+                    if (getJudgementAnimation(resultComponent.Component) != null)
+                    {
+                        // TODO: this should be inside the judgement pieces.
+                        Func<Drawable> createDrawable = () => getJudgementAnimation(resultComponent.Component);
+
+                        var particle = getParticleTexture(resultComponent.Component);
+
+                        if (particle != null)
+                            return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, particle);
+
+                        return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
+                    }
+
                     return null;
 
-                case SoyokazeSkinComponents.HitCircleText:
-                    if (!this.HasFont(LegacyFont.HitCircle))
-                        return null;
-
-                    return new LegacySpriteText(LegacyFont.HitCircle)
+                case SoyokazeSkinComponentLookup soyokazeComponent:
+                    switch (soyokazeComponent.Component)
                     {
-                        // stable applies a blanket 0.8x scale to hitcircle fonts
-                        Scale = new Vector2(0.8f),
-                    };
+                        case SoyokazeSkinComponents.ApproachCircle:
+                        case SoyokazeSkinComponents.Cursor:
+                        case SoyokazeSkinComponents.HitCircle:
+                        case SoyokazeSkinComponents.HitCircleOverlay:
+                        case SoyokazeSkinComponents.HoldOverlay:
+                        case SoyokazeSkinComponents.InputOverlayKey:
+                        case SoyokazeSkinComponents.InputOverlayBackground:
+                        case SoyokazeSkinComponents.KiaiVisualizerSquare:
+                            return null;
 
+                        case SoyokazeSkinComponents.HitCircleText:
+                            if (!this.HasFont(LegacyFont.HitCircle))
+                                return null;
+                            
+                            // stable applies a blanket 0.8x scale to hitcircle fonts;
+                            // see OsuLegacySkinTransformer.GetDrawableComponent(ISkinComponentLookup lookup)
+                            const float hitcircle_text_scale = 0.8f;
+                            return new LegacySpriteText(LegacyFont.HitCircle)
+                            {
+                                Scale = new Vector2(hitcircle_text_scale),
+                            };
+
+                        default:
+                            return base.GetDrawableComponent(lookup);
+                    }
                 default:
-                    return base.GetDrawableComponent(component);
+                    return null;
             }
         }
 
@@ -56,6 +82,51 @@ namespace osu.Game.Rulesets.Soyokaze.Skinning.Legacy
                 default:
                     return base.GetConfig<TLookup, TValue>(lookup);
             }
+        }
+
+        // This function was copied from LegacySkin.getJudgementAnimation(HitResult result)
+        private Drawable getJudgementAnimation(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Miss:
+                    return this.GetAnimation("hit0", true, false);
+
+                case HitResult.LargeTickMiss:
+                    return this.GetAnimation("slidertickmiss", true, false);
+
+                case HitResult.IgnoreMiss:
+                    return this.GetAnimation("sliderendmiss", true, false);
+
+                case HitResult.Meh:
+                    return this.GetAnimation("hit50", true, false);
+
+                case HitResult.Ok:
+                    return this.GetAnimation("hit100", true, false);
+
+                case HitResult.Great:
+                    return this.GetAnimation("hit300", true, false);
+            }
+
+            return null;
+        }
+
+        // This function was copied from LegacySkin.getParticleTexture(HitResult result)
+        private Texture getParticleTexture(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Meh:
+                    return GetTexture("particle50");
+
+                case HitResult.Ok:
+                    return GetTexture("particle100");
+
+                case HitResult.Great:
+                    return GetTexture("particle300");
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Fixes #225.

Originally this was difficult because there were too many judgements (Perfect/Good) compared to osu!std, but with #228 this is no longer the case.
