### PR TITLE
Skinning: Use separate `soyokaze/` folder for skin elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ An [osu!](https://github.com/ppy/osu) ruleset mimicking [Genshin Impact](https:/
 | --- | --- | --- |
 
 ## Skinning
-Default skin PNGs (they're all white): [/osu.Game.Rulesets.Soyokaze/Resources/Textures/Gameplay/soyokaze](/osu.Game.Rulesets.Soyokaze/Resources/Textures/Gameplay/soyokaze).
+Default skin PNGs (they're all white): [/osu.Game.Rulesets.Soyokaze/Resources/Textures/Gameplay/soyokaze](/osu.Game.Rulesets.Soyokaze/Resources/Textures/Gameplay/soyokaze). Judgements and Hit Circle text are skinnable too following normal [osu!standard skinning guidelines](https://osu.ppy.sh/wiki/en/Skinning/osu%21).
 
-Judgements and Hit Circle text are skinnable too following normal [osu!standard skinning guidelines](https://osu.ppy.sh/wiki/en/Skinning/osu%21).
+**Note:** By default, skin PNGs will be taken from the skin's root folder (i.e. where stable looks for skin PNGs). So certain elements (hit circles, approach circles, judgements) will share the same PNGs as osu!std. However, soyokaze! will also look for skin PNGs inside a separate `soyokaze/` folder (i.e. `soyokaze/hitcircle@2x.png` instead of `hitcircle@2x.png`), so it is possible to differentiate between soyokaze! and osu!std. For better organization, *all* soyokaze! PNGs can be placed inside this `soyokaze/` folder.
 
 `skin.ini` default values:
 ```

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/AbstractDefaultComponent.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/AbstractDefaultComponent.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
+// See the LICENSE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+
+namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
+{
+    public abstract partial class AbstractDefaultComponent : CompositeDrawable
+    {
+        public virtual Texture Texture { get; init; }
+
+        public AbstractDefaultComponent()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+        }
+
+        protected abstract SoyokazeSkinComponents Component { get; }
+
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures)
+        {
+            var lookup = new SoyokazeSkinComponentLookup(Component);
+            AddInternal(new Sprite
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Texture = Texture ?? textures.Get(lookup.StoreName),
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/AbstractDefaultComponent.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/AbstractDefaultComponent.cs
@@ -24,12 +24,12 @@ namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
         [BackgroundDependencyLoader]
         private void load(TextureStore textures)
         {
-            var lookup = new SoyokazeSkinComponentLookup(Component);
+            string storeName = $"Gameplay/{SoyokazeRuleset.SHORT_NAME}/{Component.ToString().ToLower()}";
             AddInternal(new Sprite
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Texture = Texture ?? textures.Get(lookup.StoreName),
+                Texture = Texture ?? textures.Get(storeName),
             });
         }
     }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultApproachCircle.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultApproachCircle.cs
@@ -1,33 +1,10 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Skinning;
-
 namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
 {
-    public partial class DefaultApproachCircle : CompositeDrawable
+    public partial class DefaultApproachCircle : AbstractDefaultComponent
     {
-        public DefaultApproachCircle()
-        {
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures, ISkinSource skin)
-        {
-            var lookup = new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.ApproachCircle);
-            AddInternal(new Sprite
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Texture = skin.GetTexture(lookup.LookupName) ?? textures.Get(lookup.StoreName),
-            });
-        }
+        protected override SoyokazeSkinComponents Component => SoyokazeSkinComponents.ApproachCircle;
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultCursor.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultCursor.cs
@@ -1,27 +1,10 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Skinning;
-
 namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
 {
-    public partial class DefaultCursor : CompositeDrawable
+    public partial class DefaultCursor : AbstractDefaultComponent
     {
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures, ISkinSource skin)
-        {
-            var textureName = new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.Cursor).LookupName;
-            AddInternal(new Sprite
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Texture = skin.GetTexture(textureName) ?? textures.Get(textureName),
-            });
-        }
+        protected override SoyokazeSkinComponents Component => SoyokazeSkinComponents.Cursor;
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultHitCircle.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultHitCircle.cs
@@ -1,33 +1,10 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Skinning;
-
 namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
 {
-    public partial class DefaultHitCircle : CompositeDrawable
+    public partial class DefaultHitCircle : AbstractDefaultComponent
     {
-        public DefaultHitCircle()
-        {
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures, ISkinSource skin)
-        {
-            var lookup = new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.HitCircle);
-            AddInternal(new Sprite
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Texture = skin.GetTexture(lookup.LookupName) ?? textures.Get(lookup.StoreName),
-            });
-        }
+        protected override SoyokazeSkinComponents Component => SoyokazeSkinComponents.HitCircle;
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultHitCircleOverlay.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultHitCircleOverlay.cs
@@ -1,33 +1,10 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Skinning;
-
 namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
 {
-    public partial class DefaultHitCircleOverlay : CompositeDrawable
+    public partial class DefaultHitCircleOverlay : AbstractDefaultComponent
     {
-        public DefaultHitCircleOverlay()
-        {
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures, ISkinSource skin)
-        {
-            var lookup = new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.HitCircleOverlay);
-            AddInternal(new Sprite
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Texture = skin.GetTexture(lookup.LookupName) ?? textures.Get(lookup.StoreName),
-            });
-        }
+        protected override SoyokazeSkinComponents Component => SoyokazeSkinComponents.HitCircleOverlay;
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultHoldOverlay.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultHoldOverlay.cs
@@ -1,34 +1,17 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
 {
-    public partial class DefaultHoldOverlay : CompositeDrawable
+    public partial class DefaultHoldOverlay : AbstractDefaultComponent
     {
+        protected override SoyokazeSkinComponents Component => SoyokazeSkinComponents.HoldOverlay;
+
         public DefaultHoldOverlay()
         {
             AutoSizeAxes = Axes.Both;
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures, ISkinSource skin)
-        {
-            var lookup = new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.HoldOverlay);
-            AddInternal(new Sprite
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Texture = skin.GetTexture(lookup.LookupName) ?? textures.Get(lookup.StoreName),
-            });
         }
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultHoldOverlayBackground.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultHoldOverlayBackground.cs
@@ -1,33 +1,10 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
-// See the LICENSE file in the repository root for full licence text.
-
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Skinning;
+// See the LICENSE file in the repository root for full licence text
 
 namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
 {
-    public partial class DefaultHoldOverlayBackground : CompositeDrawable
+    public partial class DefaultHoldOverlayBackground : AbstractDefaultComponent
     {
-        public DefaultHoldOverlayBackground()
-        {
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures, ISkinSource skin)
-        {
-            var lookup = new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.HoldOverlayBackground);
-            AddInternal(new Sprite
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Texture = skin.GetTexture(lookup.LookupName) ?? textures.Get(lookup.StoreName),
-            });
-        }
+        protected override SoyokazeSkinComponents Component => SoyokazeSkinComponents.HoldOverlayBackground;
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultInputOverlayBackground.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultInputOverlayBackground.cs
@@ -1,33 +1,10 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Skinning;
-
 namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
 {
-    public partial class DefaultInputOverlayBackground : CompositeDrawable
+    public partial class DefaultInputOverlayBackground : AbstractDefaultComponent
     {
-        public DefaultInputOverlayBackground()
-        {
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures, ISkinSource skin)
-        {
-            var lookup = new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.InputOverlayBackground);
-            AddInternal(new Sprite
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Texture = skin.GetTexture(lookup.LookupName) ?? textures.Get(lookup.StoreName),
-            });
-        }
+        protected override SoyokazeSkinComponents Component => SoyokazeSkinComponents.InputOverlayBackground;
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultInputOverlayKey.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultInputOverlayKey.cs
@@ -1,33 +1,10 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Skinning;
-
 namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
 {
-    public partial class DefaultInputOverlayKey : CompositeDrawable
+    public partial class DefaultInputOverlayKey : AbstractDefaultComponent
     {
-        public DefaultInputOverlayKey()
-        {
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures, ISkinSource skin)
-        {
-            var lookup = new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.InputOverlayKey);
-            AddInternal(new Sprite
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Texture = skin.GetTexture(lookup.LookupName) ?? textures.Get(lookup.StoreName),
-            });
-        }
+        protected override SoyokazeSkinComponents Component => SoyokazeSkinComponents.InputOverlayKey;
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultKiaiVisualizerSquare.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Defaults/DefaultKiaiVisualizerSquare.cs
@@ -1,33 +1,10 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Game.Skinning;
-
 namespace osu.Game.Rulesets.Soyokaze.Skinning.Defaults
 {
-    public partial class DefaultKiaiVisualizerSquare : CompositeDrawable
+    public partial class DefaultKiaiVisualizerSquare : AbstractDefaultComponent
     {
-        public DefaultKiaiVisualizerSquare()
-        {
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(TextureStore textures, ISkinSource skin)
-        {
-            var lookup = new SoyokazeSkinComponentLookup(SoyokazeSkinComponents.KiaiVisualizerSquare);
-            AddInternal(new Sprite
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Texture = skin.GetTexture(lookup.LookupName) ?? textures.Get(lookup.StoreName),
-            });
-        }
+        protected override SoyokazeSkinComponents Component => SoyokazeSkinComponents.KiaiVisualizerSquare;
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/Legacy/SoyokazeLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/Legacy/SoyokazeLegacySkinTransformer.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Soyokaze.Skinning.Defaults;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -23,36 +24,56 @@ namespace osu.Game.Rulesets.Soyokaze.Skinning.Legacy
             switch (lookup)
             {
                 // This was taken from LegacySkin.GetDrawableComponent(ISkinComponentLookup lookup)
-                case SkinComponentLookup<HitResult> resultComponent:
+                case SkinComponentLookup<HitResult> resultLookup:
                     // kind of wasteful that we throw this away, but should do for now.
-                    if (getJudgementAnimation(resultComponent.Component) != null)
+                    if (getJudgementAnimation(resultLookup.Component) != null)
                     {
                         // TODO: this should be inside the judgement pieces.
-                        Func<Drawable> createDrawable = () => getJudgementAnimation(resultComponent.Component);
+                        Func<Drawable> createDrawable = () => getJudgementAnimation(resultLookup.Component);
 
-                        var particle = getParticleTexture(resultComponent.Component);
+                        var particle = getParticleTexture(resultLookup.Component);
 
                         if (particle != null)
-                            return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, particle);
+                            return new LegacyJudgementPieceNew(resultLookup.Component, createDrawable, particle);
 
-                        return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
+                        return new LegacyJudgementPieceOld(resultLookup.Component, createDrawable);
                     }
 
                     return null;
 
-                case SoyokazeSkinComponentLookup soyokazeComponent:
-                    switch (soyokazeComponent.Component)
+                case SoyokazeSkinComponentLookup soyokazeLookup:
+                    string fallbackName = soyokazeLookup.Component.ToString().ToLower();
+                    string primaryName = $"{SoyokazeRuleset.SHORT_NAME}/{fallbackName}";
+                    Texture texture = GetTexture(primaryName) ?? GetTexture(fallbackName);
+
+                    switch (soyokazeLookup.Component)
                     {
                         case SoyokazeSkinComponents.ApproachCircle:
+                            return new DefaultApproachCircle { Texture = texture };
+
                         case SoyokazeSkinComponents.Cursor:
+                            return new DefaultCursor { Texture = texture };
+
                         case SoyokazeSkinComponents.HitCircle:
+                            return new DefaultHitCircle { Texture = texture };
+
                         case SoyokazeSkinComponents.HitCircleOverlay:
+                            return new DefaultHitCircleOverlay { Texture = texture };
+
                         case SoyokazeSkinComponents.HoldOverlay:
+                            return new DefaultHoldOverlay { Texture = texture };
+
                         case SoyokazeSkinComponents.HoldOverlayBackground:
+                            return new DefaultHoldOverlayBackground { Texture = texture };
+
                         case SoyokazeSkinComponents.InputOverlayKey:
+                            return new DefaultInputOverlayKey { Texture = texture };
+
                         case SoyokazeSkinComponents.InputOverlayBackground:
+                            return new DefaultInputOverlayBackground { Texture = texture };
+
                         case SoyokazeSkinComponents.KiaiVisualizerSquare:
-                            return null;
+                            return new DefaultKiaiVisualizerSquare { Texture = texture };
 
                         case SoyokazeSkinComponents.HitCircleText:
                             if (!this.HasFont(LegacyFont.HitCircle))
@@ -91,22 +112,22 @@ namespace osu.Game.Rulesets.Soyokaze.Skinning.Legacy
             switch (result)
             {
                 case HitResult.Miss:
-                    return this.GetAnimation("hit0", true, false);
+                    return this.GetAnimation($"{SoyokazeRuleset.SHORT_NAME}/hit0", true, false) ?? this.GetAnimation("hit0", true, false);
 
                 case HitResult.LargeTickMiss:
-                    return this.GetAnimation("slidertickmiss", true, false);
+                    return this.GetAnimation($"{SoyokazeRuleset.SHORT_NAME}/slidertickmiss", true, false) ?? this.GetAnimation("slidertickmiss", true, false);
 
                 case HitResult.IgnoreMiss:
-                    return this.GetAnimation("sliderendmiss", true, false);
+                    return this.GetAnimation($"{SoyokazeRuleset.SHORT_NAME}/sliderendmiss", true, false) ?? this.GetAnimation("sliderendmiss", true, false);
 
                 case HitResult.Meh:
-                    return this.GetAnimation("hit50", true, false);
+                    return this.GetAnimation($"{SoyokazeRuleset.SHORT_NAME}/hit50", true, false) ?? this.GetAnimation("hit50", true, false);
 
                 case HitResult.Ok:
-                    return this.GetAnimation("hit100", true, false);
+                    return this.GetAnimation($"{SoyokazeRuleset.SHORT_NAME}/hit100", true, false) ?? this.GetAnimation("hit100", true, false);
 
                 case HitResult.Great:
-                    return this.GetAnimation("hit300", true, false);
+                    return this.GetAnimation($"{SoyokazeRuleset.SHORT_NAME}/hit300", true, false) ?? this.GetAnimation("hit300", true, false);
             }
 
             return null;
@@ -118,13 +139,13 @@ namespace osu.Game.Rulesets.Soyokaze.Skinning.Legacy
             switch (result)
             {
                 case HitResult.Meh:
-                    return GetTexture("particle50");
+                    return GetTexture($"{SoyokazeRuleset.SHORT_NAME}/particle50") ?? GetTexture("particle50");
 
                 case HitResult.Ok:
-                    return GetTexture("particle100");
+                    return GetTexture($"{SoyokazeRuleset.SHORT_NAME}/particle100") ?? GetTexture("particle100");
 
                 case HitResult.Great:
-                    return GetTexture("particle300");
+                    return GetTexture($"{SoyokazeRuleset.SHORT_NAME}/particle300") ?? GetTexture("particle300");
             }
 
             return null;

--- a/osu.Game.Rulesets.Soyokaze/Skinning/SoyokazeSkinComponentLookup.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/SoyokazeSkinComponentLookup.cs
@@ -11,7 +11,5 @@ namespace osu.Game.Rulesets.Soyokaze.Skinning
             : base(component)
         {
         }
-
-        public string StoreName => $"Gameplay/{SoyokazeRuleset.SHORT_NAME}/{Component.ToString().ToLower()}";
     }
 }

--- a/osu.Game.Rulesets.Soyokaze/Skinning/SoyokazeSkinComponentLookup.cs
+++ b/osu.Game.Rulesets.Soyokaze/Skinning/SoyokazeSkinComponentLookup.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Soyokaze.Skinning
@@ -13,13 +12,6 @@ namespace osu.Game.Rulesets.Soyokaze.Skinning
         {
         }
 
-        // TODO: THIS IS A HORROR
-        public string LookupName => ComponentName;
-
-        public string StoreName => string.Join('/', new[] { "Gameplay", RulesetPrefix, ComponentName }.Where(s => !string.IsNullOrEmpty(s)));
-
-        public string RulesetPrefix => SoyokazeRuleset.SHORT_NAME;
-
-        public string ComponentName => Component.ToString().ToLower();
+        public string StoreName => $"Gameplay/{SoyokazeRuleset.SHORT_NAME}/{Component.ToString().ToLower()}";
     }
 }


### PR DESCRIPTION
Fixes #223.

Copied from `README.md`, which has been updated accordingly:
> By default, skin PNGs will be taken from the skin's root folder (i.e. where stable looks for skin PNGs). So certain elements (hit circles, approach circles, judgements) will share the same PNGs as osu!std. However, soyokaze! will also look for skin PNGs inside a separate `soyokaze/` folder (i.e. `soyokaze/hitcircle@2x.png` instead of `hitcircle@2x.png`), so it is possible to differentiate between soyokaze! and osu!std. For better organization, *all* soyokaze! PNGs can be placed inside this `soyokaze/` folder.

Note that hit circle text is not supported. There doesn't seem to be any easy way to add additional text types, since most of this is implemented via `static` methods with no immediate extensibility.